### PR TITLE
Update bearwear.dtx

### DIFF
--- a/bearwear.dtx
+++ b/bearwear.dtx
@@ -324,7 +324,7 @@
 
  \subsection{Coloring the shirts}
 
- The body and the arms of the shirts can be colored. They are three basic keys: \bearwearkey{leftarm}, \bearwearkey{rightarm} and \bearwearkey{body}, and two meta keys: \bearwearkey{arms} and \bearwearkey{shirt}.
+ The body and the arms of the shirts can be colored. They are three basic keys: \bearwearkey[breaklines=false]{leftarm}, \bearwearkey{rightarm} and \bearwearkey{body}, and two meta keys: \bearwearkey{arms} and \bearwearkey{shirt}.
  Basically every option that would make sense in a \lstinline|\fill|  is allowed here.
  Patterns e.g. would work too.
  \begin{tcblisting}{tikz lower}


### PR DESCRIPTION
Temporily disable `breaklines` to prevent the comma after `leftarm` to be pushed into the next line